### PR TITLE
Ensure Descriptor loads persisted configuration after controller restart

### DIFF
--- a/src/main/java/io/jenkins/plugins/wiz/WizScannerBuilder.java
+++ b/src/main/java/io/jenkins/plugins/wiz/WizScannerBuilder.java
@@ -174,6 +174,10 @@ public class WizScannerBuilder extends Builder implements SimpleBuildStep {
         private String wizCliURL;
         private String wizEnv;
 
+        public DescriptorImpl() {
+            load();
+        }
+
         @RequirePOST
         @SuppressFBWarnings(value = "SECURITY")
         public FormValidation doCheckUserInput(@QueryParameter String value) {

--- a/src/test/java/io/jenkins/plugins/wiz/WizScannerBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/wiz/WizScannerBuilderTest.java
@@ -12,10 +12,13 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+
+import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -118,5 +121,36 @@ public class WizScannerBuilderTest {
 
         // Test applicability
         assertTrue("Should be applicable to FreeStyleProject", descriptor.isApplicable(FreeStyleProject.class));
+    }
+
+    @Test
+    public void testDescriptorConfigurationSaveAndLoad() throws Exception {
+        WizScannerBuilder.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(WizScannerBuilder.DescriptorImpl.class);
+
+        String testClientId = "test-client-id";
+        String testSecretKey = "test-secret-key";
+        String testCliUrl = "https://test.wiz.io/cli";
+        String testEnv = "test-env";
+
+        JSONObject formData = new JSONObject();
+        formData.put("wizClientId", testClientId);
+        formData.put("wizSecretKey", testSecretKey);
+        formData.put("wizCliURL", testCliUrl);
+        formData.put("wizEnv", testEnv);
+
+        descriptor.configure(null, formData);
+
+        assertEquals("Client ID not saved correctly", testClientId, descriptor.getWizClientId());
+        assertEquals("Secret key not saved correctly", testSecretKey, Secret.toString(descriptor.getWizSecretKey()));
+        assertEquals("CLI URL not saved correctly", testCliUrl, descriptor.getWizCliURL());
+        assertEquals("Environment not saved correctly", testEnv, descriptor.getWizEnv());
+
+        WizScannerBuilder.DescriptorImpl newDescriptor = new WizScannerBuilder.DescriptorImpl();
+
+        assertEquals("Client ID not loaded correctly", testClientId, newDescriptor.getWizClientId());
+        assertEquals("Secret key not loaded correctly", testSecretKey, Secret.toString(newDescriptor.getWizSecretKey()));
+        assertEquals("CLI URL not loaded correctly", testCliUrl, newDescriptor.getWizCliURL());
+        assertEquals("Environment not loaded correctly", testEnv, newDescriptor.getWizEnv());
     }
 }


### PR DESCRIPTION
This pull request adds a constructor to the Descriptor class and integrates the load() method to ensure that persisted configuration is properly reloaded after the Jenkins controller is restarted. While the configuration itself was already being persisted, this change ensures that the configuration is loaded into memory on restart.

### Testing done

- Added a unit test called `testDescriptorConfigurationSaveAndLoad()` that validates the functionality of both the save and load methods to ensure the configuration is persisted and reloaded correctly.
- Manually tested the change by restarting Jenkins and rerunning the CI pipeline. Verified that the pipeline passes, demonstrating that the persisted configuration was properly loaded during the restart.
- Manually debugged the process to ensure that the configuration is correctly reloaded after Jenkins restarts, confirming that the load() method works as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
