### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -20,4 +20,4 @@ jobs:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      java-version: 11 # What version of Java to set up for the build.
+      # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.10</version>
     <relativePath />
   </parent>
 
@@ -33,7 +33,7 @@
     <revision>1.0.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.462</jenkins.baseline>
+    <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3893.v213a_42768d35</version>
+        <version>4583.v0a_f4df179fa_b_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpg-jdk18on</artifactId>
-      <version>1.78</version>
+      <version>1.80</version>
       <exclusions>
         <exclusion>
           <groupId>org.bouncycastle</groupId>

--- a/src/main/java/io/jenkins/plugins/wiz/PGPVerifier.java
+++ b/src/main/java/io/jenkins/plugins/wiz/PGPVerifier.java
@@ -154,11 +154,10 @@ public class PGPVerifier {
      * Checks if a signature indicates the key is valid for signing.
      */
     private boolean hasValidSigningFlag(Object sig, PGPPublicKey key) {
-        if (!(sig instanceof PGPSignature)) {
+        if (!(sig instanceof PGPSignature signature)) {
             return false;
         }
 
-        PGPSignature signature = (PGPSignature) sig;
         PGPSignatureSubpacketVector hashedSigs = signature.getHashedSubPackets();
 
         if (hashedSigs == null) {
@@ -218,8 +217,7 @@ public class PGPVerifier {
             JcaPGPObjectFactory pgpFactory = new JcaPGPObjectFactory(sigStream);
             Object obj = pgpFactory.nextObject();
 
-            if (obj instanceof PGPSignatureList) {
-                PGPSignatureList sigs = (PGPSignatureList) obj;
+            if (obj instanceof PGPSignatureList sigs) {
                 if (!sigs.isEmpty()) {
                     LOGGER.log(Level.FINE, "Successfully read binary signature list");
                     return sigs.get(0);
@@ -243,8 +241,7 @@ public class PGPVerifier {
             JcaPGPObjectFactory pgpFactory = new JcaPGPObjectFactory(decoderStream);
             Object obj = pgpFactory.nextObject();
 
-            if (obj instanceof PGPSignatureList) {
-                PGPSignatureList sigs = (PGPSignatureList) obj;
+            if (obj instanceof PGPSignatureList sigs) {
                 if (!sigs.isEmpty()) {
                     LOGGER.log(Level.FINE, "Successfully read ASCII armored signature list");
                     return sigs.get(0);

--- a/src/main/java/io/jenkins/plugins/wiz/WizScannerBuilder.java
+++ b/src/main/java/io/jenkins/plugins/wiz/WizScannerBuilder.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.wiz;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -23,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 public class WizScannerBuilder extends Builder implements SimpleBuildStep {
@@ -179,7 +178,6 @@ public class WizScannerBuilder extends Builder implements SimpleBuildStep {
         }
 
         @RequirePOST
-        @SuppressFBWarnings(value = "SECURITY")
         public FormValidation doCheckUserInput(@QueryParameter String value) {
             if (StringUtils.isBlank(value)) {
                 return FormValidation.error(Messages.WizScannerBuilder_DescriptorImpl_errors_missingName());
@@ -198,7 +196,7 @@ public class WizScannerBuilder extends Builder implements SimpleBuildStep {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
             wizClientId = formData.getString("wizClientId");
             wizSecretKey = Secret.fromString(formData.getString("wizSecretKey"));
             wizCliURL = formData.getString("wizCliURL");

--- a/src/test/java/io/jenkins/plugins/wiz/WizScannerBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/wiz/WizScannerBuilderTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class WizScannerBuilderTest {
 
@@ -81,8 +82,10 @@ public class WizScannerBuilderTest {
         FreeStyleProject project = j.createFreeStyleProject();
         Run<?, ?> run = project.scheduleBuild2(0).get();
 
+        StaplerRequest2 request = mock(StaplerRequest2.class);
+
         descriptor.configure(
-                null,
+                request,
                 net.sf.json.JSONObject.fromObject("{" + "'wizClientId': '',"
                         + "'wizSecretKey': '',"
                         + "'wizCliURL': '',"
@@ -137,7 +140,9 @@ public class WizScannerBuilderTest {
         formData.put("wizCliURL", expectedCliUrl);
         formData.put("wizEnv", expectedEnv);
 
-        sut.configure(null, formData);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
+
+        sut.configure(request, formData);
 
         assertEquals("Client ID not saved correctly", expectedClientId, sut.getWizClientId());
         assertEquals("Secret key not saved correctly", expectedSecretKey, Secret.toString(sut.getWizSecretKey()));


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.3 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
