### PR TITLE
fix: handle null scanStatistics from wizcli v1.43.0+

### DIFF
--- a/src/main/java/io/jenkins/plugins/wiz/WizScannerResult.java
+++ b/src/main/java/io/jenkins/plugins/wiz/WizScannerResult.java
@@ -340,8 +340,12 @@ public class WizScannerResult {
             if (root != null && root.has("result")) {
                 JSONObject result = root.getJSONObject("result");
                 if (result.has("scanStatistics")) {
+                    JSONObject scanStats = result.optJSONObject("scanStatistics");
+                    // wizcli v1.43.0+ sets scanStatistics to null; analytics path handles those counts
+                    if (scanStats == null || scanStats.isNullObject()) {
+                        return stats;
+                    }
                     ScannerAnalytics misconfigurationStatistics = new ScannerAnalytics();
-                    JSONObject scanStats = result.getJSONObject("scanStatistics");
                     misconfigurationStatistics.setInfoCount(scanStats.optInt("infoMatches", 0));
                     misconfigurationStatistics.setLowCount(scanStats.optInt("lowMatches", 0));
                     misconfigurationStatistics.setMediumCount(scanStats.optInt("mediumMatches", 0));

--- a/src/test/java/io/jenkins/plugins/wiz/WizScannerResultTest.java
+++ b/src/test/java/io/jenkins/plugins/wiz/WizScannerResultTest.java
@@ -115,6 +115,44 @@ public class WizScannerResultTest {
     }
 
     @Test
+    public void testParseJsonContentWithV1_43_NullScanStatistics() {
+        // wizcli v1.43.0+ sets result.scanStatistics to null and moves data to result.analytics
+        String jsonStr = "{"
+                + "\"scanOriginResource\": {\"name\": \"alpine:latest\"},"
+                + "\"createdAt\": \"2026-04-21T10:00:00Z\","
+                + "\"status\": {\"verdict\": \"PASSED_BY_POLICY\"},"
+                + "\"result\": {"
+                + "\"scanStatistics\": null,"
+                + "\"analytics\": {"
+                + "\"vulnerabilities\": {"
+                + "\"criticalCount\": 159,"
+                + "\"highCount\": 517,"
+                + "\"mediumCount\": 0,"
+                + "\"lowCount\": 0,"
+                + "\"infoCount\": 0,"
+                + "\"totalCount\": 676"
+                + "}"
+                + "}"
+                + "},"
+                + "\"reportUrl\": \"https://app.wiz.io/findings/123\""
+                + "}";
+
+        JSONObject root = JSONObject.fromObject(jsonStr);
+        WizScannerResult result = WizScannerResult.parseJsonContent(root);
+
+        assertNotNull("Result should not be null", result);
+        assertEquals("alpine:latest", result.getScannedResource());
+        assertEquals(WizScannerResult.ScanStatus.PASSED, result.getStatus());
+        assertTrue(result.getAnalytics().isPresent());
+
+        var vulns = result.getAnalytics().map(map -> map.get("Vulnerabilities"));
+        assertTrue("Vulnerabilities analytics should be populated from result.analytics", vulns.isPresent());
+        assertEquals(159, vulns.get().getCriticalCount());
+        assertEquals(517, vulns.get().getHighCount());
+        assertEquals(676, vulns.get().getTotalCount());
+    }
+
+    @Test
     public void testParseJsonContentWithInvalidData() {
         String jsonStr = "{" + "\"scanOriginResource\": {\"name\": \"test-resource\"},"
                 + "\"status\": {\"verdict\": \"INVALID_STATUS\"}"


### PR DESCRIPTION
wizcli v1.43.0 changed its JSON output schema: result.scanStatistics is now null, with vulnerability counts moved to result.analytics.*Count. parseMisconfigurationStatistics called getJSONObject("scanStatistics") which returned a net.sf.json null-object, causing optInt to throw JSONException: null object and leaving all widget counts at zero.

Switch to optJSONObject and bail early when the value is null so the already-correct parseScannerAnalytics path handles the new schema. Adds a regression test covering the v1.43.0 null-scanStatistics case.
