### PR TITLE
Fix v1 CLI scan result parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,30 @@
-target
+# Maven build output
+/target/
 
-# mvn hpi:run
-work
+# Jenkins plugin run output
+/work/
 
 # IntelliJ IDEA project files
 *.iml
 *.iws
 *.ipr
-.idea
+/.idea/
 
 # Eclipse project files
-.settings
+/.settings/
 .classpath
 .project
+
+# VS Code workspace files
+/.vscode/
+
+# macOS files
+.DS_Store
+
+# Logs
+*.log
+
+# Temporary/editor swap files
+*.swp
+*~
+

--- a/src/main/java/io/jenkins/plugins/wiz/WizCliRunner.java
+++ b/src/main/java/io/jenkins/plugins/wiz/WizCliRunner.java
@@ -95,7 +95,7 @@ public class WizCliRunner {
         FilePath outputFile = workspace.child(OUTPUT_FILENAME);
         FilePath errorFile = workspace.child(ERROR_FILENAME);
 
-        ArgumentListBuilder scanArgs = buildScanArguments(userInput, cliSetup);
+        ArgumentListBuilder scanArgs = buildScanArguments(userInput, cliSetup, artifactName);
         listener.getLogger().println("Executing command: " + scanArgs);
 
         int exitCode = executeScanProcess(launcher, workspace, env, scanArgs, outputFile, errorFile);
@@ -113,7 +113,7 @@ public class WizCliRunner {
     /**
      * Builds the scan command arguments, properly handling quoted strings and ensuring JSON output.
      */
-    private static ArgumentListBuilder buildScanArguments(String userInput, WizCliSetup cliSetup) {
+    private static ArgumentListBuilder buildScanArguments(String userInput, WizCliSetup cliSetup, String artifactName) {
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add(cliSetup.getCliCommand());
 
@@ -139,6 +139,9 @@ public class WizCliRunner {
                 args.add("-f", "json");
             }
         } else {
+            if (!userInput.contains("--json-output-file")) {
+                args.add("--json-output-file", artifactName);
+            }
             if (!userInput.contains("--stdout")) {
                 args.add("--stdout", "json");
             }
@@ -175,6 +178,19 @@ public class WizCliRunner {
     private static void copyOutputToArtifact(FilePath outputFile, FilePath workspace, String artifactName)
             throws IOException, InterruptedException {
         FilePath target = workspace.child(artifactName);
-        outputFile.copyTo(target);
+
+        // Wiz CLI v1 supports --json-output-file. When that file exists, it is
+        // the authoritative, parseable scan result. Do not overwrite it with
+        // raw stdout, because stdout may contain banners/progress text around
+        // the JSON payload.
+        if (target.exists() && target.length() > 0) {
+            return;
+        }
+
+        // Fallback for old CLI behavior or for commands that only write the
+        // JSON payload to stdout.
+        if (outputFile.exists() && outputFile.length() > 0) {
+            outputFile.copyTo(target);
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/wiz/WizScannerResult.java
+++ b/src/main/java/io/jenkins/plugins/wiz/WizScannerResult.java
@@ -235,13 +235,70 @@ public class WizScannerResult {
                 throw new IOException("JSON file is empty");
             }
 
-            JSONObject root = (JSONObject) JSONSerializer.toJSON(content);
+            JSONObject root = parseJsonObject(content);
             return parseJsonContent(root);
 
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to parse scan results", e);
             return null;
         }
+    }
+
+    /**
+     * Parses scan output into a JSON object. Wiz CLI v1 may emit progress/banner
+     * text around the JSON payload when stdout is captured, so fall back to
+     * extracting the first complete JSON object from mixed output.
+     */
+    private static JSONObject parseJsonObject(String content) throws IOException {
+        try {
+            return (JSONObject) JSONSerializer.toJSON(content);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Scan output was not pure JSON; attempting to extract JSON object", e);
+            return (JSONObject) JSONSerializer.toJSON(extractFirstJsonObject(content));
+        }
+    }
+
+    private static String extractFirstJsonObject(String content) throws IOException {
+        int start = content.indexOf('{');
+        if (start < 0) {
+            throw new IOException("No JSON object found in scan output");
+        }
+
+        int depth = 0;
+        boolean inString = false;
+        boolean escaped = false;
+
+        for (int i = start; i < content.length(); i++) {
+            char c = content.charAt(i);
+
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+
+            if (c == '"') {
+                inString = !inString;
+                continue;
+            }
+
+            if (!inString) {
+                if (c == '{') {
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                    if (depth == 0) {
+                        return content.substring(start, i + 1);
+                    }
+                }
+            }
+        }
+
+        throw new IOException("Could not extract a complete JSON object from scan output");
     }
 
     /**

--- a/src/test/java/io/jenkins/plugins/wiz/WizCliRunnerTest.java
+++ b/src/test/java/io/jenkins/plugins/wiz/WizCliRunnerTest.java
@@ -1,0 +1,97 @@
+package io.jenkins.plugins.wiz;
+
+import static org.junit.Assert.*;
+
+import hudson.FilePath;
+import hudson.util.ArgumentListBuilder;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class WizCliRunnerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testBuildScanArgumentsAddsJsonOutputFileForV1() throws Exception {
+        ArgumentListBuilder args = buildScanArguments(
+                "scan container-image my-nginx:9", new WizCliSetup(false, WizCliVersion.V1), "wizscan.json");
+
+        List<String> argList = args.toList();
+
+        assertTrue(argList.contains("--json-output-file"));
+        assertEquals("wizscan.json", argList.get(argList.indexOf("--json-output-file") + 1));
+        assertTrue(argList.contains("--stdout"));
+        assertEquals("json", argList.get(argList.indexOf("--stdout") + 1));
+    }
+
+    @Test
+    public void testBuildScanArgumentsDoesNotDuplicateJsonOutputFileForV1() throws Exception {
+        ArgumentListBuilder args = buildScanArguments(
+                "scan container-image my-nginx:9 --json-output-file custom.json --stdout json",
+                new WizCliSetup(false, WizCliVersion.V1),
+                "wizscan.json");
+
+        List<String> argList = args.toList();
+
+        assertEquals(1, countOccurrences(argList, "--json-output-file"));
+        assertEquals("custom.json", argList.get(argList.indexOf("--json-output-file") + 1));
+        assertEquals(1, countOccurrences(argList, "--stdout"));
+    }
+
+    @Test
+    public void testCopyOutputToArtifactDoesNotOverwriteExistingJsonFile() throws Exception {
+        FilePath workspace = new FilePath(temporaryFolder.newFolder("workspace"));
+        FilePath outputFile = workspace.child("wizcli_output");
+        FilePath artifact = workspace.child("wizscan.json");
+
+        outputFile.write("banner and mixed stdout", "UTF-8");
+        artifact.write("{\"source\":\"json-output-file\"}", "UTF-8");
+
+        copyOutputToArtifact(outputFile, workspace, "wizscan.json");
+
+        assertEquals("{\"source\":\"json-output-file\"}", artifact.readToString());
+    }
+
+    @Test
+    public void testCopyOutputToArtifactFallsBackToStdoutWhenJsonFileMissing() throws Exception {
+        FilePath workspace = new FilePath(temporaryFolder.newFolder("workspace"));
+        FilePath outputFile = workspace.child("wizcli_output");
+        FilePath artifact = workspace.child("wizscan.json");
+
+        outputFile.write("{\"source\":\"stdout\"}", "UTF-8");
+
+        copyOutputToArtifact(outputFile, workspace, "wizscan.json");
+
+        assertEquals("{\"source\":\"stdout\"}", artifact.readToString());
+    }
+
+    private static ArgumentListBuilder buildScanArguments(String userInput, WizCliSetup cliSetup, String artifactName)
+            throws Exception {
+        Method method = WizCliRunner.class.getDeclaredMethod(
+                "buildScanArguments", String.class, WizCliSetup.class, String.class);
+        method.setAccessible(true);
+        return (ArgumentListBuilder) method.invoke(null, userInput, cliSetup, artifactName);
+    }
+
+    private static void copyOutputToArtifact(FilePath outputFile, FilePath workspace, String artifactName)
+            throws Exception {
+        Method method = WizCliRunner.class.getDeclaredMethod(
+                "copyOutputToArtifact", FilePath.class, FilePath.class, String.class);
+        method.setAccessible(true);
+        method.invoke(null, outputFile, workspace, artifactName);
+    }
+
+    private static int countOccurrences(List<String> items, String needle) {
+        int count = 0;
+        for (String item : items) {
+            if (needle.equals(item)) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/wiz/WizScannerResultTest.java
+++ b/src/test/java/io/jenkins/plugins/wiz/WizScannerResultTest.java
@@ -2,10 +2,16 @@ package io.jenkins.plugins.wiz;
 
 import static org.junit.Assert.*;
 
+import hudson.FilePath;
 import net.sf.json.JSONObject;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class WizScannerResultTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testParseJsonContentWithV0_IAC() {
@@ -128,5 +134,67 @@ public class WizScannerResultTest {
 
         var vulns = result.getAnalytics().map(map -> map.get("vulnerabilities"));
         assertFalse(vulns.isPresent());
+    }
+
+    @Test
+    public void testFromJsonFileParsesPureJson() throws Exception {
+        FilePath scanFile = new FilePath(temporaryFolder.newFile("wizscan.json"));
+        scanFile.write(createContainerImageScanJson("my-nginx:9", "PASSED_BY_POLICY"), "UTF-8");
+
+        WizScannerResult result = WizScannerResult.fromJsonFile(scanFile);
+
+        assertNotNull("Result should not be null", result);
+        assertEquals("my-nginx:9", result.getScannedResource());
+        assertEquals(WizScannerResult.ScanStatus.PASSED, result.getStatus());
+        assertEquals("https://test.wiz.io/report/123", result.getReportUrl());
+        assertTrue(result.getAnalytics().isPresent());
+        assertEquals(1, result.getAnalytics().get().get("Vulnerabilities").getCriticalCount());
+    }
+
+    @Test
+    public void testFromJsonFileParsesV1MixedStdout() throws Exception {
+        String mixedOutput = "██╗    ██╗ ████╗ ███████╗\n"
+                + "Connecting to Wiz\n"
+                + "SUCCESS: Connected to Wiz\n"
+                + "Initializing scan\n"
+                + "SUCCESS: Scan initialized\n"
+                + "Scanning my-nginx:9\n"
+                + "SUCCESS: Local scanning complete\n"
+                + "Finalizing scan\n"
+                + "SUCCESS: Scan finalized\n"
+                + createContainerImageScanJson("my-nginx:9", "FAILED_BY_POLICY")
+                + "\nFAILED: Scan failed - policy failure\n";
+        FilePath scanFile = new FilePath(temporaryFolder.newFile("wizscan.json"));
+        scanFile.write(mixedOutput, "UTF-8");
+
+        WizScannerResult result = WizScannerResult.fromJsonFile(scanFile);
+
+        assertNotNull("Result should not be null for mixed v1 CLI stdout", result);
+        assertEquals("my-nginx:9", result.getScannedResource());
+        assertEquals(WizScannerResult.ScanStatus.FAILED, result.getStatus());
+        assertEquals("https://test.wiz.io/report/123", result.getReportUrl());
+        assertTrue(result.getAnalytics().isPresent());
+        assertEquals(1, result.getAnalytics().get().get("Vulnerabilities").getCriticalCount());
+    }
+
+    private static String createContainerImageScanJson(String resourceName, String verdict) {
+        return "{"
+                + "\"scanOriginResource\": {\"name\": \"" + resourceName + "\"},"
+                + "\"createdAt\": \"2026-07-01T15:12:20Z\","
+                + "\"status\": {\"verdict\": \"" + verdict + "\"},"
+                + "\"result\": {"
+                + "\"analytics\": {"
+                + "\"vulnerabilities\": {"
+                + "\"criticalCount\": 1,"
+                + "\"highCount\": 0,"
+                + "\"mediumCount\": 0,"
+                + "\"lowCount\": 0,"
+                + "\"infoCount\": 0,"
+                + "\"totalCount\": 1"
+                + "}"
+                + "}"
+                + "},"
+                + "\"reportUrl\": \"https://test.wiz.io/report/123\""
+                + "}";
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

## Summary

This PR fixes Jenkins Wiz Scanner result rendering for Wiz CLI v1 scans where the CLI scan completes successfully, publishes results to Wiz, but the Jenkins build page shows:

```text
No Scan Results Available
```

Fixes: #18
- https://github.com/jenkinsci/wiz-scanner-plugin/issues/18 

The issue was observed with Jenkins Wiz Scanner plugin `98.v292089e3108c` when running a v1 container image scan through the plugin:

```groovy
wizcli "scan container-image my-nginx:${BUILD_NUMBER}"
```

The scan itself connects, initializes, completes local scanning, finalizes, and publishes results to Wiz. However, the Jenkins **Wiz Scanner** tab may fail to render because the plugin currently relies on parsing raw stdout as JSON.

---

## Root Cause

For Wiz CLI v1, the plugin appends:

```text
--stdout json
```

and captures stdout into `wizcli_output`. It then copies that output into `wizscan.json` and parses the whole file as JSON.

In some v1 scan paths, especially `scan container-image`, stdout can contain human-readable progress output before or after the JSON payload, for example:

```text
Connecting to Wiz
SUCCESS: Connected to Wiz
Initializing scan
SUCCESS: Scan initialized
Scanning my-nginx:9
SUCCESS: Local scanning complete
Finalizing scan
SUCCESS: Scan finalized
{ ... JSON scan result ... }
FAILED: Scan failed - policy failure
```

Because the resulting `wizscan.json` is not pure JSON, `WizScannerResult.fromJsonFile()` fails to parse it, returns `null`, and the Jenkins UI renders:

```text
No Scan Results Available
```

The scan itself is not failing due to this bug. The failure is in the plugin-side result parsing/rendering path.

---

## What Changed

This PR updates Wiz CLI v1 result handling to use a dedicated JSON output file instead of treating raw stdout as the primary scan result artifact.

Changes included:

- For Wiz CLI v1, automatically add:

```text
--json-output-file wizscan.json
```

- Preserve existing `--stdout json` behavior for console/debug output.
- Do not overwrite an existing `wizscan.json` with raw `wizcli_output` when the CLI already created a valid JSON result file.
- Add parser fallback logic to extract the first valid JSON object from mixed stdout if needed.
- Add regression tests covering:
  - v1 argument construction with `--json-output-file`
  - existing user-provided `--json-output-file` not being duplicated
  - preserving existing path/directory scan behavior such as `scan dir .`
  - not overwriting an existing `wizscan.json`
  - parsing mixed stdout that contains progress text plus JSON

---

## Compatibility Notes

This change is intended to preserve the scan path functionality that already worked.

For example, an existing v1 path scan such as:

```groovy
wizcli "scan dir ."
```

will now execute effectively as:

```bash
./wizcli scan dir . --json-output-file wizscan.json --stdout json
```

The user-provided scan target `.` is preserved.

If a user already provides a JSON output file manually:

```groovy
wizcli "scan dir ./src --json-output-file=/tmp/results.json"
```

the plugin does not add a duplicate `--json-output-file` flag.

Legacy v0 behavior is unchanged. The v0 path continues to append `-f json` only when no explicit format is provided.

---

## Reproduction

Using Helm-installed Jenkins with Docker-in-Docker:

```text
Jenkins: 2.541.3
Wiz Scanner Plugin: 98.v292089e3108c
Pipeline: Kubernetes podTemplate
Docker: docker:24-cli + docker:24-dind
Command: wizcli "scan container-image my-nginx:${BUILD_NUMBER}"
```

The plugin executes:

```bash
./wizcli scan container-image my-nginx:<BUILD_NUMBER> --stdout json
```

The scan finalizes and publishes to Wiz, but the Jenkins **Wiz Scanner** tab may render:

```text
No Scan Results Available
```

After this fix, the plugin uses a dedicated JSON output file:

```bash
./wizcli scan container-image my-nginx:<BUILD_NUMBER> --json-output-file wizscan.json --stdout json
```

The Jenkins **Wiz Scanner** tab can then parse and render the scan result correctly.

---

## Validation

Validated locally with targeted unit tests:

```bash
mvn -Dtest=WizCliRunnerTest test
mvn -Dtest=WizScannerResultTest test
```

Results:

```text
WizCliRunnerTest: 4 tests run, 0 failures, 0 errors
WizScannerResultTest: 5 tests run, 0 failures, 0 errors
```

Spotless formatting was applied with a supported JDK version.

Note: Java 25 caused a local `palantir-java-format` compatibility error due to formatter/JDK internals. Validation should be run with Java 17 or Java 21.

---

## Files Changed

```text
.gitignore
src/main/java/io/jenkins/plugins/wiz/WizCliRunner.java
src/main/java/io/jenkins/plugins/wiz/WizScannerResult.java
src/test/java/io/jenkins/plugins/wiz/WizCliRunnerTest.java
src/test/java/io/jenkins/plugins/wiz/WizScannerResultTest.java
```

---

## Expected Outcome

With this change:

- v1 scans still execute normally.
- v1 path scans continue to work.
- v1 container image scans write parseable JSON to `wizscan.json`.
- Raw stdout is retained for diagnostics but is no longer allowed to overwrite the dedicated JSON result file.
- Policy-failed scans can still render in the Jenkins UI.
- The Jenkins **Wiz Scanner** tab displays scan metadata, verdict, report URL, and finding counts instead of `No Scan Results Available`.

---

## Notes

The important reproduction is not the old command:

```groovy
wizcli "docker scan --image my-nginx:${BUILD_NUMBER}"
```

and not the invalid v1 command:

```groovy
wizcli "scan container-image --image my-nginx:${BUILD_NUMBER}"
```

The important reproduction is the corrected v1 command:

```groovy
wizcli "scan container-image my-nginx:${BUILD_NUMBER}"
```

With plugin `98.v292089e3108c`, this command can successfully finalize and publish the scan while the Jenkins **Wiz Scanner** tab still renders no results. That points to plugin output handling, not user command syntax.
